### PR TITLE
为过滤项增加 点击启用/禁用 功能

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/EhDB.java
+++ b/app/src/main/java/com/hippo/ehviewer/EhDB.java
@@ -93,6 +93,19 @@ public class EhDB {
         switch (oldVersion) {
             case 1: // 1 to 2
                 FilterDao.createTable(db, true);
+                break;
+            case 2: // add ENABLE column to table FILTER
+                db.execSQL("CREATE TABLE " + "\"FILTER2\" (" +
+                    "\"_id\" INTEGER PRIMARY KEY ," +
+                    "\"MODE\" INTEGER NOT NULL ," +
+                    "\"TEXT\" TEXT," +
+                    "\"ENABLE\" INTEGER);");
+                db.execSQL("INSERT INTO \"FILTER2\" (" +
+                        "_id, MODE, TEXT, ENABLE)" +
+                        "SELECT _id, MODE, TEXT, 1 FROM FILTER;");
+                db.execSQL("DROP TABLE FILTER");
+                db.execSQL("ALTER TABLE FILTER2 RENAME TO  FILTER");
+                break;
         }
     }
 
@@ -604,6 +617,11 @@ public class EhDB {
 
     public static synchronized void deleteFilter(Filter filter) {
         sDaoSession.getFilterDao().delete(filter);
+    }
+
+    public static synchronized void triggerFilter(Filter filter) {
+        filter.setEnable(!filter.enable);
+        sDaoSession.getFilterDao().update(filter);
     }
 
     public static synchronized boolean exportDB(Context context, File file) {

--- a/app/src/main/java/com/hippo/ehviewer/client/EhFilter.java
+++ b/app/src/main/java/com/hippo/ehviewer/client/EhFilter.java
@@ -92,6 +92,8 @@ public final class EhFilter {
     }
 
     public synchronized void addFilter(Filter filter) {
+        // enable filter by default before it is added to database
+        filter.enable = true;
         EhDB.addFilter(filter);
 
         switch (filter.mode) {
@@ -114,6 +116,10 @@ public final class EhFilter {
                 Log.d(TAG, "Unknown mode: " + filter.mode);
                 break;
         }
+    }
+
+    public synchronized void triggerFilter(Filter filter) {
+        EhDB.triggerFilter(filter);
     }
 
     public synchronized void deleteFilter(Filter filter) {
@@ -153,7 +159,7 @@ public final class EhFilter {
         if (null != title && filters.size() > 0) {
             title = title.toLowerCase();
             for (int i = 0, n = filters.size(); i < n; i++) {
-                if (title.contains(filters.get(i).text)) {
+                if (filters.get(i).enable && title.contains(filters.get(i).text)) {
                     return false;
                 }
             }
@@ -172,7 +178,7 @@ public final class EhFilter {
         List<Filter> filters = mUploaderFilterList;
         if (null != uploader && filters.size() > 0) {
             for (int i = 0, n = filters.size(); i < n; i++) {
-                if (uploader.equals(filters.get(i).text)) {
+                if (filters.get(i).enable && uploader.equals(filters.get(i).text)) {
                     return false;
                 }
             }
@@ -229,7 +235,7 @@ public final class EhFilter {
         if (null != tags && filters.size() > 0) {
             for (String tag: tags) {
                 for (int i = 0, n = filters.size(); i < n; i++) {
-                    if (matchTag(tag, filters.get(i).text)) {
+                    if (filters.get(i).enable && matchTag(tag, filters.get(i).text)) {
                         return false;
                     }
                 }
@@ -264,7 +270,7 @@ public final class EhFilter {
         if (null != tags && filters.size() > 0) {
             for (String tag: tags) {
                 for (int i = 0, n = filters.size(); i < n; i++) {
-                    if (matchTagNamespace(tag, filters.get(i).text)) {
+                    if (filters.get(i).enable && matchTagNamespace(tag, filters.get(i).text)) {
                         return false;
                     }
                 }

--- a/app/src/main/java/com/hippo/ehviewer/ui/FilterActivity.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/FilterActivity.java
@@ -17,6 +17,7 @@
 package com.hippo.ehviewer.ui;
 
 import android.content.DialogInterface;
+import android.graphics.Paint;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -247,6 +248,8 @@ public class FilterActivity extends ToolbarActivity {
             if (null != icon) {
                 icon.setOnClickListener(this);
             }
+            // click on the filter text to enable/disable it
+            text.setOnClickListener(this);
         }
 
         @Override
@@ -257,7 +260,15 @@ public class FilterActivity extends ToolbarActivity {
             }
             Filter filter = mFilterList.get(position);
             if (FilterList.MODE_HEADER != filter.mode) {
-                showDeleteFilterDialog(filter);
+                if (v instanceof ImageView) {
+                    showDeleteFilterDialog(filter);
+                } else if (v instanceof TextView) {
+                    mFilterList.trigger(filter);
+
+                    //for updating delete line on filter text
+                    mAdapter.notifyDataSetChanged();
+                }
+
             }
         }
     }
@@ -314,12 +325,18 @@ public class FilterActivity extends ToolbarActivity {
                 holder.text.setText(filter.text);
             } else {
                 holder.text.setText(filter.text);
+                // add a delete line if the filter is disabled
+                if (!filter.enable) {
+                    holder.text.setPaintFlags(holder.text.getPaintFlags() | Paint.STRIKE_THRU_TEXT_FLAG);
+                } else {
+                    holder.text.setPaintFlags(holder.text.getPaintFlags() & (~Paint.STRIKE_THRU_TEXT_FLAG));
+                }
             }
         }
 
         @Override
         public int getItemCount() {
-            return null != mFilterList ? mFilterList.size(): 0;
+            return null != mFilterList ? mFilterList.size() : 0;
         }
     }
 
@@ -449,6 +466,10 @@ public class FilterActivity extends ToolbarActivity {
 
         public void delete(Filter filter) {
             mEhFilter.deleteFilter(filter);
+        }
+
+        public void trigger(Filter filter) {
+            mEhFilter.triggerFilter(filter);
         }
     }
 }

--- a/app/src/main/java/com/hippo/ehviewer/ui/FilterActivity.java
+++ b/app/src/main/java/com/hippo/ehviewer/ui/FilterActivity.java
@@ -78,6 +78,7 @@ public class FilterActivity extends ToolbarActivity {
         mRecyclerView.setClipChildren(false);
         mRecyclerView.setLayoutManager(new LinearLayoutManager(this));
         mRecyclerView.hasFixedSize();
+        mRecyclerView.setItemAnimator(null);
 
         updateView(false);
     }
@@ -266,7 +267,7 @@ public class FilterActivity extends ToolbarActivity {
                     mFilterList.trigger(filter);
 
                     //for updating delete line on filter text
-                    mAdapter.notifyDataSetChanged();
+                    mAdapter.notifyItemChanged(getAdapterPosition());
                 }
 
             }

--- a/daogenerator/src/main/java/com/hippo/ehviewer/daogenerator/EhDaoGenerator.java
+++ b/daogenerator/src/main/java/com/hippo/ehviewer/daogenerator/EhDaoGenerator.java
@@ -32,7 +32,7 @@ public class EhDaoGenerator {
     private static final String OUT_DIR = "../app/src/main/java-gen";
     private static final String DELETE_DIR = "../app/src/main/java-gen/com/hippo/ehviewer/dao";
 
-    private static final int VERSION = 2;
+    private static final int VERSION = 3;
 
     private static final String DOWNLOAD_INFO_PATH = "../app/src/main/java-gen/com/hippo/ehviewer/dao/DownloadInfo.java";
     private static final String HISTORY_INFO_PATH = "../app/src/main/java-gen/com/hippo/ehviewer/dao/HistoryInfo.java";
@@ -190,6 +190,7 @@ public class EhDaoGenerator {
         entity.addIdProperty();
         entity.addIntProperty("mode").notNull();
         entity.addStringProperty("text");
+        entity.addBooleanProperty("enable");
     }
 
     private static void adjustDownloadInfo() throws Exception {
@@ -496,6 +497,7 @@ public class EhDaoGenerator {
         // Set field public
         javaClass.getField("mode").setPublic();
         javaClass.getField("text").setPublic();
+        javaClass.getField("enable").setPublic();
         // Add equals method
         javaClass.addImport("com.hippo.yorozuya.ObjectUtils");
         javaClass.addMethod("\t@Override\n" +


### PR DESCRIPTION
现在的过滤项如果想临时禁用的话必须先删除，日后再重新添加。

这个 PR 通过在 FILTER 表里增加一列 ENABLE 来判断过滤项是否被启用
用户可以点击过滤项的文本来禁用/重新启用过滤项。

启用的过滤项和以前的显示方式一样
禁用的过滤项会多一道删除线，效果如下图

![screen](https://user-images.githubusercontent.com/8641779/34079838-fe44c958-e378-11e7-9e6c-418969c22e2b.png)
