### PR TITLE
解决 tag 中带有 "|" 时可能出现的无法过滤问题

### DIFF
--- a/app/src/main/java/com/hippo/ehviewer/client/parser/GalleryDetailParser.java
+++ b/app/src/main/java/com/hippo/ehviewer/client/parser/GalleryDetailParser.java
@@ -303,7 +303,7 @@ public class GalleryDetailParser {
                 // Sometimes parody tag is followed with '|' and english translate, just remove them
                 int index = tag.indexOf('|');
                 if (index >= 0) {
-                    tag = tag.substring(0, index);
+                    tag = tag.substring(0, index).trim();
                 }
                 group.addTag(tag);
             }


### PR DESCRIPTION
现在的版本由于一些原因在特定情况下无法过滤一些 tag，例如 parody:sailor moon。

# 问题复现

1. 搜索 sailor moon
2. 打开一个带有 parody:sailor moon 标签的 Gallery
3. 长按 Gallery 详情页面的 parody:sailor moon 标签，将其增加到过滤项中
4. 返回搜索结果列表，刷新
5. 可以看到该 Gallery 并没有被正确过滤

# 问题原因

如图 ![image](https://user-images.githubusercontent.com/8641779/34322894-22bf8f22-e877-11e7-8284-4daf7c2cdb1b.png)
网页上这个标签的内容实际上是 `sailor moon | bishoujo senshi sailor moon`

https://github.com/seven332/EhViewer/blob/3f579060b5b76ff50d0a4d33de6b11700c2e0f82/app/src/main/java/com/hippo/ehviewer/client/parser/GalleryDetailParser.java#L303-L307
这段代码对其处理后的结果字符串为 `sailor moon ` 即最后会有一个空格，导致用户在 Gallery 详情页面长按标签增加过滤项时，产生的过滤项也会带这个空格。

这个空格会使 `EhFilter#matchTag()` 返回 false，导致过滤失败。

# 此 PR 解决方案

加个 `trim()` 消除前后缀空格