### PR TITLE
French translations fix

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -433,7 +433,7 @@
     <string name="settings_read_show_progress">Montrer le progrès</string>
     <string name="settings_read_show_battery">Montrer le niveau de batterie</string>
     <string name="settings_read_show_page_interval">Montrer l\'intervalle des pages</string>
-    <string name="settings_read_volume_page">Permettre de tourner la page avec les boutons Volume</string>
+    <string name="settings_read_volume_page">Tourner la page avec les Volumes</string>
     <string name="settings_read_reading_fullscreen">Plein d\'écran</string>
     <string name="settings_read_custom_screen_lightness">Utiliser la luminosité d\'écran personalisée</string>
     <string name="settings_read_screen_lightness">Luminosité d\'écran</string>
@@ -446,7 +446,7 @@
     <string name="settings_download_pick_dir_l">Android 5.0+ a implémenté un nouveau API, qui permet les applications à écrire dans la carte SD. Appuyez sur \"DOCUMENT\" pour définir la carte SD comme la destination de téléchargement</string>
     <string name="settings_download_document">Document</string>
     <string name="settings_download_continue">Continuer</string>
-    <string name="settings_download_media_scan">Permettre le scannage des fiches multimédias</string>
+    <string name="settings_download_media_scan">Permettre le scannage multimédia</string>
     <string name="settings_download_media_scan_summary_on">Ne montre jamais vos applications galerie à personne</string>
     <string name="settings_download_media_scan_summary_off">La plupart d\'applications galerie ignorent les images dans le chemin de téléchargement</string>
     <string name="settings_download_multi_thread_download">Téléchargement multi-thread</string>
@@ -470,7 +470,7 @@
     <string name="settings_download_clean_redundancy_done">Nettoyage complété avec succès, %d objets effacés</string>
 
     <string name="settings_advanced">Avancé</string>
-    <string name="settings_advanced_save_parse_error_body">Sauvegarder le contenu de HTML après l\'erreur d\'analyse syntaxique</string>
+    <string name="settings_advanced_save_parse_error_body">Sauv. les HTMLs avec erreurs</string>
     <string name="settings_advanced_save_parse_error_body_summary">Le fiche HTML pouvait contenir les informations personnelles</string>
     <string name="settings_advanced_dump_logcat">Sauvegarder le journal logcat</string>
     <string name="settings_advanced_dump_logcat_summary">Sauvegarder le journal logcat au stockage externe</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -447,7 +447,7 @@
     <string name="settings_download_document">Document</string>
     <string name="settings_download_continue">Continuer</string>
     <string name="settings_download_media_scan">Permettre le scannage multimédia</string>
-    <string name="settings_download_media_scan_summary_on">Ne montre jamais vos applications galerie à personne</string>
+    <string name="settings_download_media_scan_summary_on">Ne montrez jamais vos applications galerie à personne</string>
     <string name="settings_download_media_scan_summary_off">La plupart d\'applications galerie ignorent les images dans le chemin de téléchargement</string>
     <string name="settings_download_multi_thread_download">Téléchargement multi-thread</string>
     <string name="settings_download_multi_thread_download_summary">Jusqu\'à %s image(s)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -456,7 +456,7 @@
     <string name="settings_download_image_resolution">Resolution d\'image</string>
     <string name="settings_download_image_resolution_summary">%s, résolutions mieux que 1280x riquent de ne pas fonctionner</string>
     <string name="settings_download_image_resolution_auto">Auto</string>
-    <string name="settings_download_download_origin_image">Télécharger l'images originales</string>
+    <string name="settings_download_download_origin_image">Télécharger l\'images originales</string>
     <string name="settings_download_download_origin_image_summary">Vous allez obtenir l\'erreur 509 plus facilement</string>
     <string name="settings_download_restore_download_items">Rétablir les galeries téléchargées</string>
     <string name="settings_download_restore_download_items_summary">Rétablir tous objets déjà téléchargés dans la destination de téléchargement</string>
@@ -637,7 +637,7 @@
     <string name="archive">Fiches archives</string>
     <string name="download_archive_failure_no_hath">Client H@H est nécessaire pour le téléchargement de fiches archives</string>
     <string name="settings_privacy">Confidentialité</string>
-    <string name="settings_privacy_secure">Empêcher captures d\'ecran</string>
+    <string name="settings_privacy_secure">Empêcher les captures d\'ecran</string>
     <string name="settings_privacy_secure_summary">Quand cette option est activée, vous ne pouvez prendre auncun capture d\'écran de l\'application, et le systéme n\'affiche pas le contenu d\'écran dans le sélecteur de tâches.\n\nRedémarrage de l\'application nécessaire pour appliquer le changement</string>
     <string name="clipboard_gallery_url_dialog_title">Lien de galerie detecté</string>
     <string name="clipboard_gallery_url_dialog_message">Voulez-vous accéder la galerie dans vos presse-papiers ?</string>
@@ -652,12 +652,12 @@
     <string name="edit_host_delete">Supprimer</string>
     <string name="invalid_host">Hôte invalide</string>
     <string name="invalid_ip">IP invalide</string>
-    <string name="page_menu_save_to">Sauvegarder dans...</string>
+    <string name="page_menu_save_to">Sauvegarder à...</string>
     <string name="settings_advanced_app_language_title">Langue de l\'app (Language)</string>
     <string name="settings_advanced_built_in_hosts_title">"hosts.txt integré "</string>
     <string name="settings_advanced_built_in_hosts_summary">Mapper l\'hôte à l\'adresse IP selon les règles de l\'app\nIls pouvent être redéfinits par hosts.txt personnalisé</string>
     <string name="settings_advanced_custom_hosts_title">hosts.txt personalisé</string>
-    <string name="settings_advanced_custom_hosts_summary">Mapper l\'hôte à l\'adresse IP\nIls pouvent redéfinir l'hosts.txt de l\'app</string>
+    <string name="settings_advanced_custom_hosts_summary">Mapper l\'hôte à l\'adresse IP\nIls pouvent redéfinir l\'hosts.txt de l\'app</string>
     <string name="app_language_system">Langue du système (défaut)</string>
 
 </resources>


### PR DESCRIPTION
Fix some apostrophes (') without backslashes, shorten some sentences.