### PR TITLE
Fixed rCN text in rTW

### DIFF
--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -662,7 +662,7 @@
     <string name="archive">壓縮檔</string>
     <string name="download_archive_failure_no_hath">下載壓縮檔需要 H@H 客戶端</string>
     <string name="settings_privacy">隱私</string>
-    <string name="settings_privacy_secure">不允許荧幕抓取</string>
+    <string name="settings_privacy_secure">不允許螢幕抓取</string>
     <string name="settings_privacy_secure_summary">啟用後，將不能截取該應用的螢幕截圖，同時，將不會在系統任務切換器中顯示該應用的內容預覽\n\n重新啟動應用以生效此更改</string>
     <string name="favorite_name">收藏畫廊</string>
 


### PR DESCRIPTION
"不允許螢幕抓取" was still rCN, fixed in this commit